### PR TITLE
DBL_MAX not found after clearing DerivedData

### DIFF
--- a/RHAddressBook/RHAddressBookSharedServices.m
+++ b/RHAddressBook/RHAddressBookSharedServices.m
@@ -42,6 +42,7 @@
 
 #import <AddressBook/AddressBook.h>
 #import <CoreLocation/CoreLocation.h>
+#import <float.h>
 
 #define PROCESS_ADDRESS_EVERY_SECONDS 5.0 //seconds between each geocode
 

--- a/RHAddressBook/RHAddressBookSharedServices.m
+++ b/RHAddressBook/RHAddressBookSharedServices.m
@@ -393,7 +393,7 @@ static __strong RHAddressBookSharedServices *_sharedInstance = nil;
 
 -(RHAddressBookGeoResult*)geoResultClosestToLocation:(CLLocation*)location distanceOut:(CLLocationDistance*)distanceOut{
 
-    CLLocationDistance distance = DBL_MAX;
+    CLLocationDistance distance = FLT_MAX;
     RHAddressBookGeoResult *result = nil;
 
     for (RHAddressBookGeoResult *entry in _cache) {


### PR DESCRIPTION
We are running our builds on a build machine that clears out the DerivedData before every build, and it keeps crashing that it can't find DBL_MAX. If I include float.h and not switch DBL_MAX then the build still fails. It works just fine when using FLT_MAX.
